### PR TITLE
chore(deps): ignore org.junit BOM major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,8 @@ updates:
     # junit.platform.version into junit.version). Block major bumps
     # until we're ready to do that as a scoped piece of work.
     ignore:
+      - dependency-name: "org.junit:*"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "org.junit.jupiter:*"
         update-types: ["version-update:semver-major"]
       - dependency-name: "org.junit.platform:*"


### PR DESCRIPTION
## Summary
- Add `org.junit:*` to dependabot's ignore list for major-version bumps
- Existing rules covered `org.junit.jupiter:*` and `org.junit.platform:*` but missed `org.junit:junit-bom`, which is the artifact dependabot actually uses to drive `junit.version` updates

## Why
Every JUnit 6 bump PR (most recently #377) fails identically on every OS/JDK combo:
```
NoSuchMethodError: 'java.util.stream.Collector
   org.junit.platform.commons.util.CollectionUtils.toUnmodifiableList()'
```
`maven-surefire-plugin` 3.5.6 — and even the latest milestone 3.6.0-M1, verified locally on this PR branch — is built against `junit-platform-commons` 1.14.x. JUnit Platform 6 removed that helper, so the forked test JVM dies before a single test runs. No released Surefire supports JUnit Platform 6 yet, so the PRs are un-mergeable upstream, not by anything we can fix here.

The existing comment in `dependabot.yml` already describes the coordinated toolchain bump this waits on (Surefire ≥ 3.x with JUnit Platform 6, drop Java 8 from CI matrix, unify `junit.platform.version` into `junit.version`). This PR just plugs the BOM artifact into the same ignore rules.

Closes upstream noise from PR #377.

## Test plan
- [ ] CI green (this only edits `.github/dependabot.yml`, no code paths touched)
- [ ] After merge: confirm dependabot no longer opens JUnit 6.x major-bump PRs on the next weekly run